### PR TITLE
Lots of updates, important optimizations, and enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: android
+android:
+  components:
+    - tools
+    - build-tools-23.0.2
+    - android-23
+    - extra-android-support
+    - extra-android-m2repository
+    - extra-google-m2repository
+
+    # Uncomment the lines below if you want to
+    # use the latest revision of Android SDK Tools
+    # - platform-tools
+    # - tools
+
+    # The BuildTools version used by your project
+    #- build-tools-23.0.2
+
+    # The SDK version used to compile your project
+    #- android-23
+
+    # Additional components
+    #- extra-google-google_play_services
+    #- extra-google-m2repository
+    #- extra-android-m2repository
+    #- addon-google_apis-google-19
+
+    # Specify at least one system image,
+    # if you need to run emulator(s) during your tests
+    #- sys-img-armeabi-v7a-android-19
+    #- sys-img-x86-android-17

--- a/README.md
+++ b/README.md
@@ -5,20 +5,40 @@ This light-weight library provides images with letter/text like the Gmail app. I
 <img src ="https://github.com/amulyakhare/TextDrawable/blob/master/screens/screen2-material.png" width="350"/>
 </p>
 
-###How to use
+# Gradle Dependency
 
-#### Import with Gradle:
+[![Release](https://jitpack.io/v/afollestad/TextDrawable.svg)](https://jitpack.io/#afollestad/TextDrawable)
+[![Build Status](https://travis-ci.org/afollestad/TextDrawable.svg)](https://travis-ci.org/afollestad/TextDrawable)
 
-```groovy
-repositories {
-    // ...
-    maven { url "https://jitpack.io" }
-}
+#### Repository
 
-dependencies {
-    compile 'com.afollestad:TextDrawable:8aa467a17d'
+Add this in your root `build.gradle` file (**not** your module `build.gradle` file):
+
+```gradle
+allprojects {
+	repositories {
+		...
+		maven { url "https://jitpack.io" }
+	}
 }
 ```
+
+#### Dependency
+
+Add this to your module's `build.gradle` file:
+
+```gradle
+dependencies {
+	...
+	compile('com.github.afollestad:TextDrawable:2056912283') {
+		transitive = true
+	}
+}
+```
+
+---
+
+### How to use
 
 ####1. Create simple tile:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.afollestad:TextDrawable:4a4892e92c'
+    compile 'com.afollestad:TextDrawable:8aa467a17d'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add this to your module's `build.gradle` file:
 ```gradle
 dependencies {
 	...
-	compile('com.github.afollestad:TextDrawable:2056912283') {
+	compile('com.github.afollestad:TextDrawable:c32bc48d86') {
 		transitive = true
 	}
 }

--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ This light-weight library provides images with letter/text like the Gmail app. I
 #### Import with Gradle:
 
 ```groovy
-repositories{
-    maven {
-        url 'http://dl.bintray.com/amulyakhare/maven'
-    }
+repositories {
+    // ...
+    maven { url "https://jitpack.io" }
 }
 
 dependencies {
-    compile 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
+    compile 'com.afollestad:TextDrawable:4a4892e92c'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ dependencies {
 ```
 **Note:** Specify width/height for the `ImageView` and the `drawable` will auto-scale to fit the size.
 ```java
-TextDrawable drawable = TextDrawable.builder()
-                .buildRect("A", Color.RED);
+TextDrawable drawable = TextDrawable.builder(this)
+    // use buildRect(String, int) for literal color value
+    .buildRectRes("A", R.color.material_red);
 
 ImageView image = (ImageView) findViewById(R.id.image_view);
 image.setImageDrawable(drawable);
@@ -46,10 +47,11 @@ image.setImageDrawable(drawable);
 
 ```java
 TextDrawable drawable1 = TextDrawable.builder()
-                .buildRoundRect("A", Color.RED, 10); // radius in px
+    // use buildRoundRect(String, int, int) for literal color value and pixel size
+    .buildRoundRectRes("A", R.color.material_red, R.dimen.radius_size); 
 
 TextDrawable drawable2 = TextDrawable.builder()
-                .buildRound("A", Color.RED);
+    .buildRound("A", Color.RED);
 ```
 
 ####3. Add border:
@@ -60,7 +62,7 @@ TextDrawable drawable2 = TextDrawable.builder()
 ```java
 TextDrawable drawable = TextDrawable.builder()
                 .beginConfig()
-                    .withBorder(4) /* thickness in px */
+                    .withBorderRes(R.dimen.border_size)  // use withBorder(int) for literal pixel size
                 .endConfig()
                 .buildRoundRect("A", Color.RED, 10);
 ```
@@ -68,11 +70,11 @@ TextDrawable drawable = TextDrawable.builder()
 ####4. Modify font style:
 
 ```java
-TextDrawable drawable = TextDrawable.builder()
+TextDrawable drawable = TextDrawable.builder(this)
                 .beginConfig()
-	                .textColor(Color.BLACK)
+	                .textColorRes(android.R.color.black)  // use textColor(int) for literal color value
                     .useFont(Typeface.DEFAULT)
-                    .fontSize(30) /* size in px */
+                    .fontSizeRes(R.dimen.title_size)  // use fontSize(int) for literal pixel size
                     .bold()
                     .toUpperCase()
                 .endConfig()
@@ -89,9 +91,9 @@ int color1 = generator.getRandomColor();
 int color2 = generator.getColor("user@gmail.com")
 
 // declare the builder object once.
-TextDrawable.IBuilder builder = TextDrawable.builder()
+TextDrawable.IBuilder builder = TextDrawable.builder(this)
 				.beginConfig()
-					.withBorder(4)
+					.withBorderRes(R.dimen.border_size)  // use withBorder(int) for literal values
 				.endConfig()
 				.rect();
 
@@ -105,17 +107,17 @@ TextDrawable ic2 = builder.build("B", color2);
 ```xml
 <ImageView android:layout_width="wrap_content"
 	       android:layout_height="wrap_content"
-	       android:id="@+id/image_view"/>
+	       android:id="@+id/image_view" />
 ```
 **Note:**  The `ImageView` could use `wrap_content` width/height. You could set the width/height of the `drawable` using code.
 
 ```java
-TextDrawable drawable = TextDrawable.builder()
+TextDrawable drawable = TextDrawable.builder(this)
 				.beginConfig()
-					.width(60)  // width in px
-					.height(60) // height in px
+					.widthRes(R.dimen.thumbnail_size)  // use width(int) for literal values
+					.heightRes(R.dimen.thumbnail_size)  // use height(int) for literal values
 				.endConfig()
-                .buildRect("A", Color.RED);
+                .buildRectRes("A", R.color.material_red);  // use buildRect(String, int) for literal color value
 
 ImageView image = (ImageView) findViewById(R.id.image_view);
 image.setImageDrawable(drawable);

--- a/TextDrawable.iml
+++ b/TextDrawable.iml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="TextDrawable" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
         <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
+        <option name="BUILDABLE" value="false" />
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
     <output url="file://$MODULE_DIR$/build/classes/main" />
     <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <exclude-output />
@@ -18,4 +19,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,9 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-annotations:23.0.1'
+    compile 'com.android.support:support-annotations:23.1.0'
 }
 
 sourceSets {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 2
         versionName "1.1"
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,6 +20,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:support-annotations:23.0.1'
 }
 
 sourceSets {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 9
         targetSdkVersion 23
         versionCode 2
         versionName "1.1"
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-annotations:23.1.0'
+    compile 'com.android.support:support-annotations:23.1.1'
 }
 
 sourceSets {

--- a/library/library.iml
+++ b/library/library.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="TextDrawable" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":library" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="TextDrawable" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -9,11 +9,15 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugTest" />
-        <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
-        <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugTestSources" />
+        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
+        <afterSyncTasks>
+          <task>generateDebugAndroidTestSources</task>
+          <task>generateDebugSources</task>
+        </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
@@ -23,8 +27,9 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/androidTest/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
@@ -32,13 +37,13 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/test/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/test/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/test/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/test/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/test/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/test/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -79,12 +84,10 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/library/library.iml
+++ b/library/library.iml
@@ -89,5 +89,6 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" exported="" name="support-annotations-23.0.1" level="project" />
   </component>
 </module>

--- a/library/src/main/java/com/amulyakhare/textdrawable/TextDrawable.java
+++ b/library/src/main/java/com/amulyakhare/textdrawable/TextDrawable.java
@@ -6,6 +6,8 @@ import android.graphics.drawable.shapes.OvalShape;
 import android.graphics.drawable.shapes.RectShape;
 import android.graphics.drawable.shapes.RoundRectShape;
 
+import com.amulyakhare.textdrawable.util.TypefaceHelper;
+
 /**
  * @author amulya
  * @datetime 14 Oct 2014, 3:53 PM
@@ -170,7 +172,7 @@ public class TextDrawable extends ShapeDrawable {
             width = -1;
             height = -1;
             shape = new RectShape();
-            font = Typeface.create("sans-serif-light", Typeface.NORMAL);
+            font = TypefaceHelper.get("sans-serif-light", Typeface.NORMAL);
             fontSize = -1;
             isBold = false;
             toUpperCase = false;

--- a/library/src/main/java/com/amulyakhare/textdrawable/TextDrawable.java
+++ b/library/src/main/java/com/amulyakhare/textdrawable/TextDrawable.java
@@ -1,5 +1,6 @@
 package com.amulyakhare.textdrawable;
 
+import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.ColorFilter;
@@ -12,6 +13,11 @@ import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.shapes.OvalShape;
 import android.graphics.drawable.shapes.RectShape;
 import android.graphics.drawable.shapes.RoundRectShape;
+import android.support.annotation.ColorInt;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DimenRes;
+import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
 
 import com.amulyakhare.textdrawable.util.TypefaceHelper;
 
@@ -25,7 +31,6 @@ public class TextDrawable extends ShapeDrawable {
     private final Paint borderPaint;
     private static final float SHADE_FACTOR = 0.9f;
     private final String text;
-    private final int color;
     private final RectShape shape;
     private final int height;
     private final int width;
@@ -44,7 +49,6 @@ public class TextDrawable extends ShapeDrawable {
 
         // text and color
         text = builder.toUpperCase ? builder.text.toUpperCase() : builder.text;
-        color = builder.color;
 
         // text paint settings
         fontSize = builder.fontSize;
@@ -60,17 +64,17 @@ public class TextDrawable extends ShapeDrawable {
         // border paint settings
         borderThickness = builder.borderThickness;
         borderPaint = new Paint();
-        borderPaint.setColor(getDarkerShade(color));
+        borderPaint.setColor(getDarkerShade(builder.color));
         borderPaint.setStyle(Paint.Style.STROKE);
         borderPaint.setStrokeWidth(borderThickness);
 
         // drawable paint color
         Paint paint = getPaint();
-        paint.setColor(color);
+        paint.setColor(builder.color);
 
     }
 
-    private int getDarkerShade(int color) {
+    private int getDarkerShade(@ColorInt int color) {
         return Color.rgb((int) (SHADE_FACTOR * Color.red(color)),
                 (int) (SHADE_FACTOR * Color.green(color)),
                 (int) (SHADE_FACTOR * Color.blue(color)));
@@ -82,9 +86,8 @@ public class TextDrawable extends ShapeDrawable {
         Rect r = getBounds();
 
         // draw border
-        if (borderThickness > 0) {
+        if (borderThickness > 0)
             drawBorder(canvas);
-        }
 
         int count = canvas.save();
         canvas.translate(r.left, r.top);
@@ -114,7 +117,7 @@ public class TextDrawable extends ShapeDrawable {
     }
 
     @Override
-    public void setAlpha(int alpha) {
+    public void setAlpha(@IntRange(from = 0, to = 255) int alpha) {
         textPaint.setAlpha(alpha);
     }
 
@@ -138,37 +141,28 @@ public class TextDrawable extends ShapeDrawable {
         return height;
     }
 
-    public static IShapeBuilder builder() {
-        return new Builder();
+    public static IShapeBuilder builder(@NonNull Context context) {
+        return new Builder(context);
     }
 
     public static class Builder implements IConfigBuilder, IShapeBuilder, IBuilder {
 
+        private Context context;
         private String text;
-
         private int color;
-
         private int borderThickness;
-
         private int width;
-
         private int height;
-
         private Typeface font;
-
         private RectShape shape;
-
         public int textColor;
-
         private int fontSize;
-
         private boolean isBold;
-
         private boolean toUpperCase;
-
         public float radius;
 
-        private Builder() {
+        private Builder(@NonNull Context context) {
+            this.context = context;
             text = "";
             color = Color.GRAY;
             textColor = Color.WHITE;
@@ -181,41 +175,81 @@ public class TextDrawable extends ShapeDrawable {
             toUpperCase = false;
         }
 
-        public IConfigBuilder width(int width) {
+        @Override
+        public IConfigBuilder width(@IntRange(from = 1, to = Integer.MAX_VALUE) int width) {
             this.width = width;
             return this;
         }
 
-        public IConfigBuilder height(int height) {
+        @Override
+        public IConfigBuilder widthRes(@DimenRes int widthRes) {
+            return width((int) context.getResources().getDimension(widthRes));
+        }
+
+        @Override
+        public IConfigBuilder height(@IntRange(from = 1, to = Integer.MAX_VALUE) int height) {
             this.height = height;
             return this;
         }
 
-        public IConfigBuilder textColor(int color) {
+        @Override
+        public IConfigBuilder heightRes(@DimenRes int heightRes) {
+            return height((int) context.getResources().getDimension(heightRes));
+        }
+
+        @Override
+        public IConfigBuilder textColor(@ColorInt int color) {
             this.textColor = color;
             return this;
         }
 
-        public IConfigBuilder withBorder(int thickness) {
+        @Override
+        public IConfigBuilder textColorRes(@ColorRes int color) {
+            //noinspection deprecation
+            return textColor(context.getResources().getColor(color));
+        }
+
+        @Override
+        public IConfigBuilder withBorder(@IntRange(from = 1, to = Integer.MAX_VALUE) int thickness) {
             this.borderThickness = thickness;
             return this;
         }
 
-        public IConfigBuilder useFont(Typeface font) {
+        @Override
+        public IConfigBuilder withBorderRes(@DimenRes int thicknessRes) {
+            return withBorder((int) context.getResources().getDimension(thicknessRes));
+        }
+
+        @Override
+        public IConfigBuilder useFont(@NonNull Typeface font) {
             this.font = font;
             return this;
         }
 
-        public IConfigBuilder fontSize(int size) {
+        @Override
+        public IConfigBuilder useFont(@NonNull String name, int style) {
+            this.font = TypefaceHelper.get(name, style);
+            return this;
+        }
+
+        @Override
+        public IConfigBuilder fontSize(@IntRange(from = 1, to = Integer.MAX_VALUE) int size) {
             this.fontSize = size;
             return this;
         }
 
+        @Override
+        public IConfigBuilder fontSizeRes(@DimenRes int sizeRes) {
+            return fontSize((int) context.getResources().getDimension(sizeRes));
+        }
+
+        @Override
         public IConfigBuilder bold() {
             this.isBold = true;
             return this;
         }
 
+        @Override
         public IConfigBuilder toUpperCase() {
             this.toUpperCase = true;
             return this;
@@ -244,7 +278,7 @@ public class TextDrawable extends ShapeDrawable {
         }
 
         @Override
-        public IBuilder roundRect(int radius) {
+        public IBuilder roundRect(@IntRange(from = 1, to = Integer.MAX_VALUE) int radius) {
             this.radius = radius;
             float[] radii = {radius, radius, radius, radius, radius, radius, radius, radius};
             this.shape = new RoundRectShape(radii, null, null);
@@ -252,45 +286,88 @@ public class TextDrawable extends ShapeDrawable {
         }
 
         @Override
-        public TextDrawable buildRect(String text, int color) {
+        public IBuilder roundRectRes(@IntRange(from = 1, to = Integer.MAX_VALUE) int radius) {
+            return roundRect((int) context.getResources().getDimension(radius));
+        }
+
+        @Override
+        public TextDrawable buildRect(@NonNull String text, @ColorInt int color) {
             rect();
             return build(text, color);
         }
 
         @Override
-        public TextDrawable buildRoundRect(String text, int color, int radius) {
+        public TextDrawable buildRectRes(@NonNull String text, @ColorRes int colorRes) {
+            rect();
+            //noinspection deprecation
+            return build(text, context.getResources().getColor(colorRes));
+        }
+
+        @Override
+        public TextDrawable buildRoundRect(@NonNull String text, @ColorInt int color, @IntRange(from = 1, to = Integer.MAX_VALUE) int radius) {
             roundRect(radius);
             return build(text, color);
         }
 
         @Override
-        public TextDrawable buildRound(String text, int color) {
+        public TextDrawable buildRoundRectRes(@NonNull String text, @ColorRes int colorRes, @DimenRes int radiusRes) {
+            //noinspection deprecation
+            return buildRoundRect(text, context.getResources().getColor(colorRes),
+                    (int) context.getResources().getDimension(radiusRes));
+        }
+
+        @Override
+        public TextDrawable buildRound(@NonNull String text, @ColorInt int color) {
             round();
             return build(text, color);
         }
 
         @Override
-        public TextDrawable build(String text, int color) {
+        public TextDrawable buildRoundRes(@NonNull String text, @ColorRes int colorRes) {
+            //noinspection deprecation
+            return buildRound(text, context.getResources().getColor(colorRes));
+        }
+
+        @Override
+        public TextDrawable build(@NonNull String text, @ColorInt int color) {
             if (this.font == null)
                 this.font = TypefaceHelper.get("sans-serif-light", Typeface.NORMAL);
             this.color = color;
             this.text = text;
             return new TextDrawable(this);
         }
+
+        @Override
+        public TextDrawable buildRes(@NonNull String text, @ColorRes int colorRes) {
+            //noinspection deprecation
+            return build(text, context.getResources().getColor(colorRes));
+        }
     }
 
     public interface IConfigBuilder {
-        IConfigBuilder width(int width);
+        IConfigBuilder width(@IntRange(from = 1, to = Integer.MAX_VALUE) int width);
 
-        IConfigBuilder height(int height);
+        IConfigBuilder widthRes(@DimenRes int width);
 
-        IConfigBuilder textColor(int color);
+        IConfigBuilder height(@IntRange(from = 1, to = Integer.MAX_VALUE) int height);
 
-        IConfigBuilder withBorder(int thickness);
+        IConfigBuilder heightRes(@DimenRes int height);
 
-        IConfigBuilder useFont(Typeface font);
+        IConfigBuilder textColor(@ColorInt int color);
 
-        IConfigBuilder fontSize(int size);
+        IConfigBuilder textColorRes(@ColorRes int colorRes);
+
+        IConfigBuilder withBorder(@IntRange(from = 1, to = Integer.MAX_VALUE) int thickness);
+
+        IConfigBuilder withBorderRes(@DimenRes int thickness);
+
+        IConfigBuilder useFont(@NonNull Typeface font);
+
+        IConfigBuilder useFont(@NonNull String name, int style);
+
+        IConfigBuilder fontSize(@IntRange(from = 1, to = Integer.MAX_VALUE) int size);
+
+        IConfigBuilder fontSizeRes(@DimenRes int size);
 
         IConfigBuilder bold();
 
@@ -301,7 +378,9 @@ public class TextDrawable extends ShapeDrawable {
 
     public interface IBuilder {
 
-        TextDrawable build(String text, int color);
+        TextDrawable build(@NonNull String text, @ColorInt int color);
+
+        TextDrawable buildRes(@NonNull String text, @ColorRes int colorRes);
     }
 
     public interface IShapeBuilder {
@@ -312,12 +391,20 @@ public class TextDrawable extends ShapeDrawable {
 
         IBuilder round();
 
-        IBuilder roundRect(int radius);
+        IBuilder roundRect(@IntRange(from = 1, to = Integer.MAX_VALUE) int radius);
 
-        TextDrawable buildRect(String text, int color);
+        IBuilder roundRectRes(@DimenRes int radius);
 
-        TextDrawable buildRoundRect(String text, int color, int radius);
+        TextDrawable buildRect(@NonNull String text, @ColorInt int color);
 
-        TextDrawable buildRound(String text, int color);
+        TextDrawable buildRectRes(@NonNull String text, @ColorRes int colorRes);
+
+        TextDrawable buildRoundRect(@NonNull String text, @ColorInt int color, @IntRange(from = 1, to = Integer.MAX_VALUE) int radius);
+
+        TextDrawable buildRoundRectRes(@NonNull String text, @ColorRes int colorRes, @IntRange(from = 1, to = Integer.MAX_VALUE) int radius);
+
+        TextDrawable buildRound(@NonNull String text, @ColorInt int color);
+
+        TextDrawable buildRoundRes(@NonNull String text, @ColorRes int colorRes);
     }
 }

--- a/library/src/main/java/com/amulyakhare/textdrawable/TextDrawable.java
+++ b/library/src/main/java/com/amulyakhare/textdrawable/TextDrawable.java
@@ -1,6 +1,13 @@
 package com.amulyakhare.textdrawable;
 
-import android.graphics.*;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.Typeface;
 import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.shapes.OvalShape;
 import android.graphics.drawable.shapes.RectShape;
@@ -64,16 +71,15 @@ public class TextDrawable extends ShapeDrawable {
     }
 
     private int getDarkerShade(int color) {
-        return Color.rgb((int)(SHADE_FACTOR * Color.red(color)),
-                (int)(SHADE_FACTOR * Color.green(color)),
-                (int)(SHADE_FACTOR * Color.blue(color)));
+        return Color.rgb((int) (SHADE_FACTOR * Color.red(color)),
+                (int) (SHADE_FACTOR * Color.green(color)),
+                (int) (SHADE_FACTOR * Color.blue(color)));
     }
 
     @Override
     public void draw(Canvas canvas) {
         super.draw(canvas);
         Rect r = getBounds();
-
 
         // draw border
         if (borderThickness > 0) {
@@ -96,15 +102,13 @@ public class TextDrawable extends ShapeDrawable {
 
     private void drawBorder(Canvas canvas) {
         RectF rect = new RectF(getBounds());
-        rect.inset(borderThickness/2, borderThickness/2);
+        rect.inset(borderThickness / 2, borderThickness / 2);
 
         if (shape instanceof OvalShape) {
             canvas.drawOval(rect, borderPaint);
-        }
-        else if (shape instanceof RoundRectShape) {
+        } else if (shape instanceof RoundRectShape) {
             canvas.drawRoundRect(rect, radius, radius, borderPaint);
-        }
-        else {
+        } else {
             canvas.drawRect(rect, borderPaint);
         }
     }
@@ -172,7 +176,6 @@ public class TextDrawable extends ShapeDrawable {
             width = -1;
             height = -1;
             shape = new RectShape();
-            font = TypefaceHelper.get("sans-serif-light", Typeface.NORMAL);
             fontSize = -1;
             isBold = false;
             toUpperCase = false;
@@ -268,6 +271,8 @@ public class TextDrawable extends ShapeDrawable {
 
         @Override
         public TextDrawable build(String text, int color) {
+            if (this.font == null)
+                this.font = TypefaceHelper.get("sans-serif-light", Typeface.NORMAL);
             this.color = color;
             this.text = text;
             return new TextDrawable(this);
@@ -275,44 +280,44 @@ public class TextDrawable extends ShapeDrawable {
     }
 
     public interface IConfigBuilder {
-        public IConfigBuilder width(int width);
+        IConfigBuilder width(int width);
 
-        public IConfigBuilder height(int height);
+        IConfigBuilder height(int height);
 
-        public IConfigBuilder textColor(int color);
+        IConfigBuilder textColor(int color);
 
-        public IConfigBuilder withBorder(int thickness);
+        IConfigBuilder withBorder(int thickness);
 
-        public IConfigBuilder useFont(Typeface font);
+        IConfigBuilder useFont(Typeface font);
 
-        public IConfigBuilder fontSize(int size);
+        IConfigBuilder fontSize(int size);
 
-        public IConfigBuilder bold();
+        IConfigBuilder bold();
 
-        public IConfigBuilder toUpperCase();
+        IConfigBuilder toUpperCase();
 
-        public IShapeBuilder endConfig();
+        IShapeBuilder endConfig();
     }
 
-    public static interface IBuilder {
+    public interface IBuilder {
 
-        public TextDrawable build(String text, int color);
+        TextDrawable build(String text, int color);
     }
 
-    public static interface IShapeBuilder {
+    public interface IShapeBuilder {
 
-        public IConfigBuilder beginConfig();
+        IConfigBuilder beginConfig();
 
-        public IBuilder rect();
+        IBuilder rect();
 
-        public IBuilder round();
+        IBuilder round();
 
-        public IBuilder roundRect(int radius);
+        IBuilder roundRect(int radius);
 
-        public TextDrawable buildRect(String text, int color);
+        TextDrawable buildRect(String text, int color);
 
-        public TextDrawable buildRoundRect(String text, int color, int radius);
+        TextDrawable buildRoundRect(String text, int color, int radius);
 
-        public TextDrawable buildRound(String text, int color);
+        TextDrawable buildRound(String text, int color);
     }
 }

--- a/library/src/main/java/com/amulyakhare/textdrawable/util/TypefaceHelper.java
+++ b/library/src/main/java/com/amulyakhare/textdrawable/util/TypefaceHelper.java
@@ -1,0 +1,47 @@
+package com.amulyakhare.textdrawable.util;
+
+import android.graphics.Typeface;
+
+import java.util.HashMap;
+
+/**
+    Each call to Typeface.createFromAsset will load a new instance of the typeface into memory,
+    and this memory is not consistently get garbage collected
+    http://code.google.com/p/android/issues/detail?id=9904
+    (It states released but even on Lollipop you can see the typefaces accumulate even after
+    multiple GC passes)
+
+    You can detect this by running:
+    adb shell dumpsys meminfo com.your.packagenage
+
+    You will see output like:
+
+     Asset Allocations
+        zip:/data/app/com.your.packagenage-1.apk:/assets/Roboto-Medium.ttf: 125K
+        zip:/data/app/com.your.packagenage-1.apk:/assets/Roboto-Medium.ttf: 125K
+        zip:/data/app/com.your.packagenage-1.apk:/assets/Roboto-Medium.ttf: 125K
+        zip:/data/app/com.your.packagenage-1.apk:/assets/Roboto-Regular.ttf: 123K
+        zip:/data/app/com.your.packagenage-1.apk:/assets/Roboto-Medium.ttf: 125K
+
+    @author Aidan Follestad (afollestad), Kevin Barry (teslacoil)
+
+**/
+public class TypefaceHelper {
+
+    private static final HashMap<String, Typeface> cache = new HashMap<>();
+
+    public static Typeface get(String name, int style) {
+        synchronized (cache) {
+            if (!cache.containsKey(name)) {
+                try {
+                    Typeface t = Typeface.create(name, style);
+                    cache.put(name, t);
+                    return t;
+                } catch (RuntimeException e) {
+                    return null;
+                }
+            }
+            return cache.get(name);
+        }
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.amulyakhare.td"
-        minSdkVersion 10
+        minSdkVersion 9
         targetSdkVersion 23
         versionCode 2
         versionName "1.0"
@@ -22,5 +22,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:appcompat-v7:23.1.1'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "com.amulyakhare.td"
         minSdkVersion 10
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 2
         versionName "1.0"
     }
@@ -22,5 +22,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:23.0.1'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:23.1.0'
 }

--- a/sample/sample.iml
+++ b/sample/sample.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="TextDrawable" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":sample" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="TextDrawable" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -9,11 +9,15 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugTest" />
-        <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
-        <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugTestSources" />
+        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
+        <afterSyncTasks>
+          <task>generateDebugAndroidTestSources</task>
+          <task>generateDebugSources</task>
+        </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
@@ -22,8 +26,9 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/androidTest/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
@@ -31,13 +36,13 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/test/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/test/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/test/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/test/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/test/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/test/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -66,6 +71,8 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.0.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
@@ -81,12 +88,11 @@
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="appcompat-v7-21.0.3" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-21.0.3" level="project" />
-    <orderEntry type="library" exported="" name="support-v4-21.0.3" level="project" />
+    <orderEntry type="library" exported="" name="appcompat-v7-23.0.1" level="project" />
+    <orderEntry type="library" exported="" name="support-v4-23.0.1" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.0.1" level="project" />
     <orderEntry type="module" module-name="library" exported="" />
   </component>
 </module>
-

--- a/sample/src/main/java/com/amulyakhare/td/sample/ListActivity.java
+++ b/sample/src/main/java/com/amulyakhare/td/sample/ListActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
@@ -19,7 +20,7 @@ import com.amulyakhare.textdrawable.util.ColorGenerator;
 import java.util.Arrays;
 import java.util.List;
 
-public class ListActivity extends ActionBarActivity {
+public class ListActivity extends AppCompatActivity {
 
     private static final int HIGHLIGHT_COLOR = 0x999be6ff;
 

--- a/sample/src/main/java/com/amulyakhare/td/sample/ListActivity.java
+++ b/sample/src/main/java/com/amulyakhare/td/sample/ListActivity.java
@@ -58,33 +58,33 @@ public class ListActivity extends ActionBarActivity {
         // initialize the builder based on the "TYPE"
         switch (type) {
             case DrawableProvider.SAMPLE_RECT:
-                mDrawableBuilder = TextDrawable.builder()
+                mDrawableBuilder = TextDrawable.builder(this)
                         .rect();
                 break;
             case DrawableProvider.SAMPLE_ROUND_RECT:
-                mDrawableBuilder = TextDrawable.builder()
+                mDrawableBuilder = TextDrawable.builder(this)
                         .roundRect(10);
                 break;
             case DrawableProvider.SAMPLE_ROUND:
-                mDrawableBuilder = TextDrawable.builder()
+                mDrawableBuilder = TextDrawable.builder(this)
                         .round();
                 break;
             case DrawableProvider.SAMPLE_RECT_BORDER:
-                mDrawableBuilder = TextDrawable.builder()
+                mDrawableBuilder = TextDrawable.builder(this)
                         .beginConfig()
                             .withBorder(4)
                         .endConfig()
                         .rect();
                 break;
             case DrawableProvider.SAMPLE_ROUND_RECT_BORDER:
-                mDrawableBuilder = TextDrawable.builder()
+                mDrawableBuilder = TextDrawable.builder(this)
                         .beginConfig()
                             .withBorder(4)
                         .endConfig()
                         .roundRect(10);
                 break;
             case DrawableProvider.SAMPLE_ROUND_BORDER:
-                mDrawableBuilder = TextDrawable.builder()
+                mDrawableBuilder = TextDrawable.builder(this)
                         .beginConfig()
                             .withBorder(4)
                         .endConfig()

--- a/sample/src/main/java/com/amulyakhare/td/sample/MainActivity.java
+++ b/sample/src/main/java/com/amulyakhare/td/sample/MainActivity.java
@@ -5,6 +5,7 @@ import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.*;
@@ -13,7 +14,7 @@ import com.amulyakhare.td.R;
 import com.amulyakhare.td.sample.sample.DataItem;
 import com.amulyakhare.td.sample.sample.DataSource;
 
-public class MainActivity extends ActionBarActivity implements AdapterView.OnItemClickListener {
+public class MainActivity extends AppCompatActivity implements AdapterView.OnItemClickListener {
 
     public static final String TYPE = "TYPE";
     private DataSource mDataSource;

--- a/sample/src/main/java/com/amulyakhare/td/sample/sample/DrawableProvider.java
+++ b/sample/src/main/java/com/amulyakhare/td/sample/sample/DrawableProvider.java
@@ -40,22 +40,22 @@ public class DrawableProvider {
     }
 
     public TextDrawable getRect(String text) {
-        return TextDrawable.builder()
+        return TextDrawable.builder(mContext)
                 .buildRect(text, mGenerator.getColor(text));
     }
 
     public TextDrawable getRound(String text) {
-        return TextDrawable.builder()
+        return TextDrawable.builder(mContext)
                 .buildRound(text, mGenerator.getColor(text));
     }
 
     public TextDrawable getRoundRect(String text) {
-        return TextDrawable.builder()
+        return TextDrawable.builder(mContext)
                 .buildRoundRect(text, mGenerator.getColor(text), toPx(10));
     }
 
     public TextDrawable getRectWithBorder(String text) {
-        return TextDrawable.builder()
+        return TextDrawable.builder(mContext)
                 .beginConfig()
                     .withBorder(toPx(2))
                 .endConfig()
@@ -63,7 +63,7 @@ public class DrawableProvider {
     }
 
     public TextDrawable getRoundWithBorder(String text) {
-        return TextDrawable.builder()
+        return TextDrawable.builder(mContext)
                 .beginConfig()
                     .withBorder(toPx(2))
                 .endConfig()
@@ -71,7 +71,7 @@ public class DrawableProvider {
     }
 
     public TextDrawable getRoundRectWithBorder(String text) {
-        return TextDrawable.builder()
+        return TextDrawable.builder(mContext)
                 .beginConfig()
                     .withBorder(toPx(2))
                 .endConfig()
@@ -80,7 +80,7 @@ public class DrawableProvider {
 
     public TextDrawable getRectWithMultiLetter() {
         String text = "AK";
-        return TextDrawable.builder()
+        return TextDrawable.builder(mContext)
                 .beginConfig()
                     .fontSize(toPx(20))
                     .toUpperCase()
@@ -90,7 +90,7 @@ public class DrawableProvider {
 
     public TextDrawable getRoundWithCustomFont() {
         String text = "Bold";
-        return TextDrawable.builder()
+        return TextDrawable.builder(mContext)
                 .beginConfig()
                     .useFont(Typeface.DEFAULT)
                     .fontSize(toPx(15))
@@ -104,7 +104,7 @@ public class DrawableProvider {
         String leftText = "I";
         String rightText = "J";
 
-        TextDrawable.IBuilder builder = TextDrawable.builder()
+        TextDrawable.IBuilder builder = TextDrawable.builder(mContext)
                 .beginConfig()
                     .width(toPx(29))
                     .withBorder(toPx(2))
@@ -125,7 +125,7 @@ public class DrawableProvider {
     }
 
     public Drawable getRectWithAnimation() {
-        TextDrawable.IBuilder builder = TextDrawable.builder()
+        TextDrawable.IBuilder builder = TextDrawable.builder(mContext)
                 .rect();
 
         AnimationDrawable animationDrawable = new AnimationDrawable();


### PR DESCRIPTION
1. Updates:
   - Updated Gradle Plugin to 1.3.0
   - Updated Gradle to 2.5
   - Updated Build Tools to 23.0.1
   - Updated the Target SDK to 23, and the compile API level to 23
   - Updated AppCompat to 23.0.1
2. `TypefaceHelper` is used to avoid duplicate allocations of fonts. For an example, if you had a list of 1,000 items using `TextDrawables`, 1,000 Typefaces would be allocated before. Now, typefaces are cached and re-used. 
   - I took this class from my own library, Material Dialogs (https://github.com/afollestad/material-dialogs). I originally did this at recommendation of Nova Launcher's developer.
3. The default font (`sans-serif-light`) is only allocated _if_ the user does not set their own font before making a call to `build()` or one of the variants of that method.
4. Added versions of build methods that take resource IDs for colors and dimensions.
5. Added annotations to builder method parameters to enforce the use of correct parameter values (e.g. numbers greater than 0, colors, dimensions, etc.)

If you end up looking at this pull request, I'll put your original Bintray dependency back in the README. I'd recommend using JitPack.io instead though. Bintray is only useful if you actually publish to jCenter, which you don't.
