### PR TITLE
Changed library and sample minSDK to api 8

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "21.1.1"
 
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 8
         targetSdkVersion 21
         versionCode 2
         versionName "1.1"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.amulyakhare.td"
-        minSdkVersion 10
+        minSdkVersion 8
         targetSdkVersion 21
         versionCode 2
         versionName "1.0"


### PR DESCRIPTION
I am developing an android application and i want to support until api 9.
I was needing something like this library. Then i just tried to change the min api version and worked nicely (i tested with the sample only).

And looks like that the library already support until 8 android api (at least),
because there was no compilation errors nor related warnings. 

I hope that it can be useful to others.
