### PR TITLE
Add support for AboutLibraries

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,11 +9,14 @@ android {
         targetSdkVersion 21
         versionCode 2
         versionName "1.1"
+        versionNameSuffix ".debug"
+        resValue "string", "lib_text_drawable_version", "${defaultConfig.versionName}${versionNameSuffix}"
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            resValue "string", "lib_text_drawable_version", "${defaultConfig.versionName}"
         }
     }
 }

--- a/library/src/main/res/values/lib_info_strings.xml
+++ b/library/src/main/res/values/lib_info_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+	<string name="define_amulyakharetextdrawable"></string>
+	<!-- Author section -->
+	<string name="library_amulyakharetextdrawable_author">Amulya Khare</string>
+	<string name="library_amulyakharetextdrawable_authorWebsite">http://www.wix.com/amulyakhare/portfolio</string>
+	<!-- Library section -->
+	<string name="library_amulyakharetextdrawable_libraryName">TextDrawable</string>
+	<string name="library_amulyakharetextdrawable_libraryDescription">This light-weight library provides images with letter/text like the Gmail app. It extends the Drawable class thus can be used with existing/custom/network ImageView classes. Also included is a fluent interface for creating drawables and a customizable ColorGenerator.</string>
+	<string name="library_amulyakharetextdrawable_libraryWebsite">https://github.com/amulyakhare/TextDrawable</string>
+	<string name="library_amulyakharetextdrawable_libraryVersion">@string/lib_text_drawable_version</string>
+	<!-- OpenSource section -->
+	<string name="library_amulyakharetextdrawable_isOpenSource">true</string>
+	<string name="library_amulyakharetextdrawable_repositoryLink">https://github.com/amulyakhare/TextDrawable</string>
+	<!-- ClassPath for autoDetect section -->
+	<string name="library_amulyakharetextdrawable_classPath">com.amulyakhare:com.amulyakhare.textdrawable</string>
+	<!-- License section -->
+	<string name="library_amulyakharetextdrawable_licenseId">mit</string>
+	<!-- Custom variables section -->
+</resources>


### PR DESCRIPTION
The [AboutLibraries](https://github.com/mikepenz/AboutLibraries) library allows you to easily create an used open source libraries fragment/activity within your app. It looks much better than text and doesn't need much of work for implementation.

I was unable to test it with the original Gradle and build tools (as my Android Studio doesn't support that), but at least with Gradle 3.0.0 it works fine for me. The newer gradle is used for debug version suffix (so you can optimally omit the update).

Reference:
https://github.com/mikepenz/AboutLibraries/wiki/HOWTODEV:-Include-in-your-library